### PR TITLE
Dev

### DIFF
--- a/LVLImport/Loaders/ModelLoader.cs
+++ b/LVLImport/Loaders/ModelLoader.cs
@@ -72,6 +72,12 @@ public class ModelLoader : Loader {
             dataOffset += vBufLength;
         }
 
+        // flip x
+        for (int vertIdx = 0; vertIdx < positions.Length; ++vertIdx)
+        {
+            positions[vertIdx].x = -positions[vertIdx].x;
+        }
+
         mesh.SetVertices(positions);
         mesh.SetNormals(normals);
         mesh.SetUVs(0,texcoords);
@@ -79,7 +85,15 @@ public class ModelLoader : Loader {
         i = 0;
         foreach (Segment seg in segments)
         {
-            mesh.SetTriangles(seg.GetIndexBuffer(), i, true, offsets[i]);
+            ushort[] indices = seg.GetIndexBuffer();
+            for (int ii = 0; ii < indices.Length; ii += 3)
+            {
+                ushort tmp = indices[ii];
+                indices[ii] = indices[ii + 2];
+                indices[ii + 2] = tmp;
+            }
+
+            mesh.SetTriangles(indices, i, true, offsets[i]);
             i++;
         }
 

--- a/LVLImport/Loaders/TextureLoader.cs
+++ b/LVLImport/Loaders/TextureLoader.cs
@@ -29,8 +29,6 @@ public class TextureLoader : Loader {
     }
 
 
-
-
     public Texture2D ImportTexture(string name) 
     {
         if (texDataBase.ContainsKey(name))
@@ -42,15 +40,10 @@ public class TextureLoader : Loader {
 
         if (tex != null && tex.width * tex.width > 0)
         {
-            Texture2D newTexture = new Texture2D(tex.width,tex.height);
+            Texture2D newTexture = new Texture2D(tex.width, tex.height, TextureFormat.RGBA32, false);
+            newTexture.name = tex.name;
             byte[] data = tex.GetBytesRGBA();
-
-            Color[] colors = newTexture.GetPixels(0);
-            for (int i = 0; i < tex.height * tex.width; i++)
-            {
-                colors[i] = new Color(data[i*4]/255.0f,data[i*4 + 1]/255.0f,data[i*4 + 2]/255.0f,data[i*4 + 3]/255.0f);
-            }
-            newTexture.SetPixels(colors,0);
+            newTexture.LoadRawTextureData(MirrorVertically(tex.GetBytesRGBA(), tex.width, tex.height, 4));
             newTexture.Apply();
 
             if (SaveAssets)
@@ -63,8 +56,21 @@ public class TextureLoader : Loader {
         }
         else 
         {
-            Debug.LogError(String.Format("Texture: {0} failed to load!", name));
+            Debug.LogWarningFormat("Texture: {0} failed to load!", name);
             return null;
         }
+    }
+
+
+    static byte[] MirrorVertically(byte[] data, int width, int height, int stride)
+    {
+        int byteWidth = width * stride;
+        byte[] mirrored = new byte[data.Length];
+        for (int rowIdx = 0; rowIdx < height; ++rowIdx)
+        {
+            int rowReverseIdx = height - rowIdx - 1;
+            Array.Copy(data, rowReverseIdx * byteWidth, mirrored, rowIdx * byteWidth, byteWidth);
+        }
+        return mirrored;
     }
 }

--- a/LVLImport/Loaders/WorldLoader.cs
+++ b/LVLImport/Loaders/WorldLoader.cs
@@ -171,7 +171,7 @@ public class WorldLoader : Loader {
 
             instanceObject.transform.rotation = UnityUtils.QuatFromLibWorld(inst.rotation);
             instanceObject.transform.position = UnityUtils.Vec3FromLibWorld(inst.position);
-            instanceObject.transform.localScale = new Vector3(-1.0f,1.0f,1.0f);
+            instanceObject.transform.localScale = new Vector3(1.0f,1.0f,1.0f);
             instanceObjects.Add(instanceObject);
         }
 


### PR DESCRIPTION
Flipped vertex X positions instead of scaling the object to X = -1 (constant negative scale warnings + bad performance), flipped the indices accordingly.

Texture now get initialized by copying the whole pixel buffer once, instead of per pixel.

Added vertical mirroring to textures.